### PR TITLE
Move physics to package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ find_package(Eigen3 REQUIRED)
 find_package(SFML COMPONENTS graphics REQUIRED)
 find_package(jsoncpp REQUIRED)
 
+find_package(aaveq_dynamics REQUIRED)
 find_package(aaveq_ros_interfaces REQUIRED)
 
 ############################################################################
@@ -58,6 +59,7 @@ install(
 ## usv
 add_library(usv src/usv.cpp)
 target_link_libraries(usv actuator propeller Eigen3::Eigen jsoncpp)
+ament_target_dependencies(usv aaveq_dynamics)
 ament_export_targets(usv HAS_LIBRARY_TARGET)
 
 install(

--- a/include/usv_sim_2d/usv.hpp
+++ b/include/usv_sim_2d/usv.hpp
@@ -28,6 +28,7 @@ public:
     void load_vessel_config(std::string vessel_config_path);
     Eigen::Vector<double, 6> compute_forces(const std::array<uint16_t, 16> &servo_out);
     bool rigid_body_dynamics(const Eigen::Vector<double, 6> &tau);
+    bool update_state(const Eigen::Vector<double, 6> &tau);
 
     std::vector<Eigen::Vector3d> get_points_of_mass() { return points_of_mass_earth_; };
     std::vector<Eigen::Vector3d> get_points_of_hull() { return points_of_hull_earth_; };

--- a/include/usv_sim_2d/usv.hpp
+++ b/include/usv_sim_2d/usv.hpp
@@ -41,11 +41,10 @@ private:
     std::vector<Eigen::Vector3d> points_of_hull_;
     std::vector<Eigen::Vector3d> points_of_hull_earth_;
     std::vector<Eigen::Vector3d> points_of_actuators_earth_;
+    std::vector<Actuator *> actuators_;
     std::vector<double> forces_of_actuators_;
     Eigen::Vector3d origin_;
     double mass_;
-
-    std::vector<Actuator *> actuators_;
 
     Eigen::Vector<double, 6> state_body_{0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
     Eigen::Vector<double, 6> state_earth_{0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
@@ -58,11 +57,11 @@ private:
     double get_time();
     double update_timestamp();
     void set_initial_condition(const Eigen::Vector<double, 6> &initial_condition);
-    Eigen::Vector3d recompute_relative_to_origin(const Eigen::Vector3d &point, const Eigen::Vector3d &com);
-    std::vector<Eigen::Vector3d> recompute_relative_to_origin(const std::vector<Eigen::Vector3d> &points, const Eigen::Vector3d &com);
-    PointMass recompute_relative_to_origin(const PointMass &point, const Eigen::Vector3d &com);
-    std::vector<PointMass> recompute_relative_to_origin(const std::vector<PointMass> &points, const Eigen::Vector3d &com);
     double compute_mass(const std::vector<ADynamics::PointMass> &points);
     Eigen::Vector3d compute_com(const std::vector<ADynamics::PointMass> &points, const double &mass);
 
+    template <typename EigenVec>
+    EigenVec recompute_relative_to_origin(const EigenVec &point, const Eigen::Vector3d &com);
+    template <typename EigenVec>
+    std::vector<EigenVec> recompute_relative_to_origin(const std::vector<EigenVec> &points, const Eigen::Vector3d &com);
 };

--- a/include/usv_sim_2d/usv.hpp
+++ b/include/usv_sim_2d/usv.hpp
@@ -22,14 +22,6 @@ public:
         Eigen::Vector3d velocity;
     } state;
 
-    struct PointMass
-    {
-        double m;
-        double x;
-        double y;
-        double z;
-    };
-
     USV();
     ~USV() {}
 
@@ -44,7 +36,7 @@ public:
 
 private:
     // Member variables
-    std::vector<PointMass> points_of_mass_;
+    std::vector<ADynamics::PointMass> points_of_mass_;
     std::vector<Eigen::Vector3d> points_of_mass_earth_;
     std::vector<Eigen::Vector3d> points_of_hull_;
     std::vector<Eigen::Vector3d> points_of_hull_earth_;
@@ -67,14 +59,14 @@ private:
     double get_time();
     double update_timestamp();
     void set_initial_condition(const Eigen::Vector<double, 6> &initial_condition);
-    double compute_mass(const std::vector<PointMass> &points);
-    Eigen::Vector3d compute_com(const std::vector<PointMass> &points, const double &mass);
     Eigen::Vector3d recompute_relative_to_origin(const Eigen::Vector3d &point, const Eigen::Vector3d &com);
     std::vector<Eigen::Vector3d> recompute_relative_to_origin(const std::vector<Eigen::Vector3d> &points, const Eigen::Vector3d &com);
     PointMass recompute_relative_to_origin(const PointMass &point, const Eigen::Vector3d &com);
     std::vector<PointMass> recompute_relative_to_origin(const std::vector<PointMass> &points, const Eigen::Vector3d &com);
     Eigen::Matrix3d skew_symmetric_matrix(const Eigen::Vector3d &v);
     Eigen::Matrix<double, 6, 6> matrix_inverse(const Eigen::Matrix<double, 6, 6> &matrix);
+    double compute_mass(const std::vector<ADynamics::PointMass> &points);
+    Eigen::Vector3d compute_com(const std::vector<ADynamics::PointMass> &points, const double &mass);
 
     Eigen::Matrix3d inertia_matrix(const std::vector<PointMass> &points);
     Eigen::Matrix<double, 6, 6> mass_matrix(const double &mass, const Eigen::Matrix3d &inertia_matrix);

--- a/include/usv_sim_2d/usv.hpp
+++ b/include/usv_sim_2d/usv.hpp
@@ -4,6 +4,8 @@
 #include <time.h>
 #include <Eigen/Dense>
 
+#include "aaveq_dynamics/adynamics.hpp"
+
 #include "usv_sim_2d/actuator.hpp"
 
 class USV

--- a/include/usv_sim_2d/usv.hpp
+++ b/include/usv_sim_2d/usv.hpp
@@ -48,9 +48,8 @@ private:
 
     std::vector<Actuator *> actuators_;
 
-    Eigen::Vector<double, 6> nu_{0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
-    Eigen::Vector<double, 6> eta_{0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
-
+    Eigen::Vector<double, 6> state_body_{0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+    Eigen::Vector<double, 6> state_earth_{0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
     Eigen::Matrix3d inertia_matrix_;
     Eigen::Matrix<double, 6, 6> mass_matrix_;
 

--- a/include/usv_sim_2d/usv.hpp
+++ b/include/usv_sim_2d/usv.hpp
@@ -27,7 +27,6 @@ public:
 
     void load_vessel_config(std::string vessel_config_path);
     Eigen::Vector<double, 6> compute_forces(const std::array<uint16_t, 16> &servo_out);
-    bool rigid_body_dynamics(const Eigen::Vector<double, 6> &tau);
     bool update_state(const Eigen::Vector<double, 6> &tau);
 
     std::vector<Eigen::Vector3d> get_points_of_mass() { return points_of_mass_earth_; };
@@ -63,15 +62,7 @@ private:
     std::vector<Eigen::Vector3d> recompute_relative_to_origin(const std::vector<Eigen::Vector3d> &points, const Eigen::Vector3d &com);
     PointMass recompute_relative_to_origin(const PointMass &point, const Eigen::Vector3d &com);
     std::vector<PointMass> recompute_relative_to_origin(const std::vector<PointMass> &points, const Eigen::Vector3d &com);
-    Eigen::Matrix3d skew_symmetric_matrix(const Eigen::Vector3d &v);
-    Eigen::Matrix<double, 6, 6> matrix_inverse(const Eigen::Matrix<double, 6, 6> &matrix);
     double compute_mass(const std::vector<ADynamics::PointMass> &points);
     Eigen::Vector3d compute_com(const std::vector<ADynamics::PointMass> &points, const double &mass);
 
-    Eigen::Matrix3d inertia_matrix(const std::vector<PointMass> &points);
-    Eigen::Matrix<double, 6, 6> mass_matrix(const double &mass, const Eigen::Matrix3d &inertia_matrix);
-    Eigen::Matrix<double, 6, 6> coriolis_matrix(const double &mass, const Eigen::Matrix3d &inertia_matrix, const Eigen::Vector<double, 6> &nu);
-    Eigen::Matrix3d rotation_matrix_eb(const Eigen::Vector3d &attitude);
-    Eigen::Matrix3d transformation_matrix(const Eigen::Vector3d &attitude);
-    Eigen::Matrix<double, 6, 6> J_Theta(const Eigen::Vector<double, 6> &eta);
 };

--- a/nodes/sim.cpp
+++ b/nodes/sim.cpp
@@ -64,7 +64,7 @@ private:
         // Calculate USV physics
         Eigen::Vector<double, 6> tau = usv_.compute_forces(servo_out_);
 
-        if (!usv_.rigid_body_dynamics(tau))
+        if (!usv_.update_state(tau))
         {
             RCLCPP_WARN_STREAM(get_logger(), "Physics update has caused an exit");
             return;

--- a/package.xml
+++ b/package.xml
@@ -16,6 +16,7 @@
   <exec_depend>sfml-dev</exec_depend>
   <exec_depend>libjsoncpp-dev</exec_depend>
 
+  <exec_depend>aaveq_dynamics</exec_depend>
   <exec_depend>aaveq_ros_interfaces</exec_depend>
 
   <export>

--- a/src/usv.cpp
+++ b/src/usv.cpp
@@ -190,9 +190,10 @@ Eigen::Vector3d USV::compute_com(const std::vector<ADynamics::PointMass> &points
     return com;
 }
 
-Eigen::Vector3d USV::recompute_relative_to_origin(const Eigen::Vector3d &point, const Eigen::Vector3d &com)
+template <typename EigenVec>
+EigenVec USV::recompute_relative_to_origin(const EigenVec &point, const Eigen::Vector3d &com)
 {
-    Eigen::Vector3d point_recomputed = point;
+    EigenVec point_recomputed = point;
 
     // Recompute coordinates of points relative to com (origin)
     point_recomputed.x() -= com.x();
@@ -202,9 +203,10 @@ Eigen::Vector3d USV::recompute_relative_to_origin(const Eigen::Vector3d &point, 
     return point_recomputed;
 }
 
-std::vector<Eigen::Vector3d> USV::recompute_relative_to_origin(const std::vector<Eigen::Vector3d> &points, const Eigen::Vector3d &com)
+template <typename EigenVec>
+std::vector<EigenVec> USV::recompute_relative_to_origin(const std::vector<EigenVec> &points, const Eigen::Vector3d &com)
 {
-    std::vector<Eigen::Vector3d> points_recomputed = points;
+    std::vector<EigenVec> points_recomputed = points;
 
     // Recompute coordinates of points relative to com (origin)
     size_t i = 0;
@@ -216,31 +218,3 @@ std::vector<Eigen::Vector3d> USV::recompute_relative_to_origin(const std::vector
 
     return points_recomputed;
 }
-
-USV::PointMass USV::recompute_relative_to_origin(const USV::PointMass &point, const Eigen::Vector3d &com)
-{
-    USV::PointMass point_recomputed = point;
-
-    // Recompute coordinates of points relative to com (origin)
-    point_recomputed.x -= com.x();
-    point_recomputed.y -= com.y();
-    point_recomputed.z -= com.z();
-
-    return point_recomputed;
-}
-
-std::vector<USV::PointMass> USV::recompute_relative_to_origin(const std::vector<USV::PointMass> &points, const Eigen::Vector3d &com)
-{
-    std::vector<USV::PointMass> points_recomputed = points;
-
-    // Recompute coordinates of points relative to com (origin)
-    size_t i = 0;
-    for (auto point : points_recomputed)
-    {
-        points_recomputed[i] = recompute_relative_to_origin(point, com);
-        i++;
-    }
-
-    return points_recomputed;
-}
-

--- a/src/usv.cpp
+++ b/src/usv.cpp
@@ -67,7 +67,7 @@ Eigen::Vector<double, 6> USV::compute_forces(const std::array<uint16_t, 16> &ser
     return tau;
 }
 
-bool USV::rigid_body_dynamics(const Eigen::Vector<double, 6> &tau)
+bool USV::update_state(const Eigen::Vector<double, 6> &tau)
 {
     // Update time
     double timestep = update_timestamp();

--- a/src/usv.cpp
+++ b/src/usv.cpp
@@ -74,6 +74,9 @@ bool USV::update_state(const Eigen::Vector<double, 6> &tau)
     if (timestep < 0.0)
         return false;
 
+    Eigen::Vector<double, 6> state_body_dot;
+    Eigen::Vector<double, 6> state_earth_dot;
+
     // Rigid body dynamics
     Eigen::Vector<double, 6> nu_dot = matrix_inverse(mass_matrix_) * tau - matrix_inverse(mass_matrix_) * coriolis_matrix(mass_, inertia_matrix_, nu_) * nu_;
     nu_dot *= timestep;
@@ -85,11 +88,11 @@ bool USV::update_state(const Eigen::Vector<double, 6> &tau)
     eta_ += eta_dot;
 
     // Pass values
-    state.gyro = nu_.tail(3);
-    state.accel = nu_dot.head(3);
-    state.position = eta_.head(3);
-    state.attitude = eta_.tail(3);
-    state.velocity = eta_dot.head(3);
+    state.gyro = state_body_.tail(3);
+    state.accel = state_body_dot.head(3);
+    state.position = state_earth_.head(3);
+    state.attitude = state_earth_.tail(3);
+    state.velocity = state_earth_dot.head(3);
 
     // Body to Earth
     points_of_mass_earth_.clear();
@@ -164,7 +167,7 @@ double USV::update_timestamp()
 
 void USV::set_initial_condition(const Eigen::Vector<double, 6> &initial_condition)
 {
-    eta_ = initial_condition;
+    state_earth_ = initial_condition;
 }
 
 double USV::compute_mass(const std::vector<ADynamics::PointMass> &points)


### PR DESCRIPTION
**WHY**

The functions that compute the dynamics are not unique to this simulation and should be moved to its own package [aaveq_dynamics](https://github.com/Aaveq-Robotics/aaveq_dynamics) for general use in the future.
It is also to avoid "[code smell](https://en.wikipedia.org/wiki/Code_smell)", mainly the violation of the [SRP](https://en.wikipedia.org/wiki/Single-responsibility_principle).

**WHAT**

- A new package has been created which contains the needed functions [aaveq_dynamics](https://github.com/Aaveq-Robotics/aaveq_dynamics)  
- Delete redundant functions from this package, and use the ones from the new package instead
- [Made template function to avoid having multiple copies](https://github.com/Aaveq-Robotics/usv_sim_2d/commit/2af1344bb8b9bc23f59fd2b41c88605f94eda1d8)

**RELATED**
Blocked by: https://github.com/Aaveq-Robotics/usv_sim_2d/pull/21, https://github.com/Aaveq-Robotics/aaveq_dynamics/pull/1